### PR TITLE
A better background detector.

### DIFF
--- a/term-background.bash
+++ b/term-background.bash
@@ -130,7 +130,7 @@ xterm_compatible_fg_bg() {
   [[ -z $fg ]] && return 1
   # Convert to array
   typeset -p fg
-  IFS='/' read -ra RGB_fg <<< "$fg"
+  IFS='/' read -ra RGB_fg <<<"$fg"
   typeset -p RGB_fg
 
   # Turn TTY off
@@ -148,7 +148,7 @@ xterm_compatible_fg_bg() {
   [[ -z $bg ]] && return 1
   # Convert to array
   typeset -p bg
-  IFS='/' read -ra RGB_bg <<< "$bg"
+  IFS='/' read -ra RGB_bg <<<"$bg"
   typeset -p RGB_bg
   xterm_osc_done=1
   return 0

--- a/term-background.bash
+++ b/term-background.bash
@@ -91,7 +91,7 @@ is_dark_colorfgbg() {
 }
 
 is_sourced() {
-  if [[ $0 == "BASH_SOURCE[0]}" ]]; then
+  if [[ $0 == "${BASH_SOURCE[0]}" ]]; then
     return 1
   else
     return 0

--- a/term-background.bash
+++ b/term-background.bash
@@ -21,80 +21,91 @@
 # Try to determine if we have dark or light terminal background
 
 typeset -i success=0
-typeset    method="xterm control"
+typeset method="xterm control"
 
 # On return, variable is_dark_bg is set
 # We follow Emacs logic (at least initially)
-get_default_bg() {
-    if [[ -n $COLORFGBG ]] ; then
-	method="COLORFGBG"
-	is_dark_colorfgbg
-    elif [[ -n $TERM ]] ; then
-	case $TERM in
-	    xterm-256color )
-		# 382.5 = (* .6 (+ 255 255 255))
-		TERMINAL_COLOR_MIDPOINT=${TERMINAL_COLOR_MIDPOINT:-383}
-		;;
-	    xterm* | dtterm | eterm* )
-		# 117963 = (* .6 (+ 65535 65535 65535))
-		TERMINAL_COLOR_MIDPOINT=${TERMINAL_COLOR_MIDPOINT:-117963}
-		is_dark_bg=0
-		;;
+get_default_colorfgbg() {
+  if [[ -n $COLORFGBG ]]; then
+    method="COLORFGBG"
+    is_dark_colorfgbg
+  elif [[ -n $TERM ]]; then
+    case $TERM in
+    xterm-256color)
+      # 382.5 = (* .6 (+ 255 255 255))
+      TERMINAL_COLOR_MIDPOINT=${TERMINAL_COLOR_MIDPOINT:-383}
+      ;;
+    xterm* | dtterm | eterm*)
+      # 117963 = (* .6 (+ 65535 65535 65535))
+      TERMINAL_COLOR_MIDPOINT=${TERMINAL_COLOR_MIDPOINT:-117963}
+      is_dark_bg=0
+      ;;
 
-	    * )
-		TERMINAL_COLOR_MIDPOINT=${TERMINAL_COLOR_MIDPOINT:-117963}
-		is_dark_bg=1
-		;;
-	esac
-    fi
+    *)
+      TERMINAL_COLOR_MIDPOINT=${TERMINAL_COLOR_MIDPOINT:-117963}
+      is_dark_bg=1
+      ;;
+    esac
+  fi
 }
 
 # Pass as parameters R G B values in hex
+# Compare FG to BG for light/dark, not just FB and midpoint
+# NOTE: We could have FG=#403020 BG=#203040 and tie
 # On return, variable is_dark_bg is set
 is_dark_rgb() {
-    typeset r g b
-    r=$1; g=$2; b=$3
-    if (( (16#$r + 16#$g + 16#$b) < TERMINAL_COLOR_MIDPOINT )) ; then
-	is_dark_bg=1
-    else
-	is_dark_bg=0
-    fi
+  typeset fg_r fg_g fg_b
+  typeset bg_r bg_g bg_b
+  fg_r=$1
+  fg_g=$2
+  fg_b=$3
+  bg_r=$4
+  bg_g=$5
+  bg_b=$6
+  a_fg=$((16#"$fg_r" + 16#"$fg_g" + 16#"$fg_b"))
+  a_bg=$((16#"$bg_r" + 16#"$bg_g" + 16#"$bg_b"))
+  echo "Avg test: a_fg: $a_fg a_bg: $a_bg"
+  if [[ $a_fg -gt $a_bg ]]; then
+    is_dark_bg=1
+  else
+    is_dark_bg=0
+  fi
 }
 
 # Consult (environment) variable COLORFGB
 # On return, variable is_dark_bg is set
 is_dark_colorfgbg() {
-    case $COLORFGBG in
-	'15;0' | '15;default;0' )
-	    is_dark_bg=1
-	    success=1
-	    ;;
-	'0;15' | '0;default;15' )
-	    is_dark_bg=0
-	    success=1
-	    ;;
-	* )
-	    is_dark_bg=-1
-	    ;;
-    esac
+  case $COLORFGBG in
+  '15;0' | '15;default;0')
+    is_dark_bg=1
+    success=1
+    ;;
+  '0;15' | '0;default;15')
+    is_dark_bg=0
+    success=1
+    ;;
+  *)
+    is_dark_bg=-1
+    ;;
+  esac
 }
 
 is_sourced() {
-    if [[ $0 == "${BASH_SOURCE[0]}" ]] ; then
-	return 1
-    else
-	return 0
-    fi
+  if [[ $0 == "BASH_SOURCE[0]}" ]]; then
+    return 1
+  else
+    return 0
+  fi
 }
 
 # Exit if we are not source.
 # if sourced, then we just set exitrc
 # which was assumed to be declared outside
 exit_if_not_sourced() {
-    exitrc=${1:-0}
-    if ! is_sourced ; then
-	exit "$exitrc"
-    fi
+  exitrc=${1:-0}
+  if ! is_sourced; then
+    exit "$exitrc"
+  fi
 }
 
 # From:
@@ -104,107 +115,146 @@ exit_if_not_sourced() {
 #
 # User should set up RGB_fg and RGB_bg arrays
 xterm_compatible_fg_bg() {
-    typeset fg bg
-    stty -echo 2>/dev/null
-    # Issue command to get both foreground and
-    # background color
-    #            fg       bg
-    echo -ne '\e]10;?\a\e]11;?\a'
-    IFS=: read -t 0.1 -d $'\a' x fg
-    IFS=: read -t 0.1 -d $'\a' x bg
-    stty echo 2>/dev/null
-    [[ -z $bg ]] && return 1
-    typeset -p fg
-    typeset -p bg
-    IFS='/' read -ra RGB_fg <<< $fg
-    IFS='/' read -ra RGB_bg <<< $bg
-    typeset -p RGB_fg
-    typeset -p RGB_bg
-    return 0
+  typeset fg bg
+  # Turn TTY off
+  stty -echo 2>/dev/null
+  # Issue command to get foreground
+  echo -ne '\e]10;?\a'
+  # Read back in terminal program reporting its OSC fg values
+  IFS=: read -t 0.1 -d $'\a' x fg
+  # Turn TTY back on
+  stty echo 2>/dev/null
+  # Remove any escape or control characters
+  # Note: gnome-terminal tacked \e at end
+  fg=$(echo "$fg" | sed 's/[^a-zA-Z0-9/]//g')
+  [[ -z $fg ]] && return 1
+  # Convert to array
+  typeset -p fg
+  IFS='/' read -ra RGB_fg <<< "$fg"
+  typeset -p RGB_fg
+
+  # Turn TTY off
+  stty -echo 2>/dev/null
+  # Issue command to get background
+  echo -ne '\e]11;?\a'
+  # Read back in terminal program reporting its OSC bg values
+  # purposely reading x, then discarding it.
+  IFS=: read -t 0.1 -d $'\a' x bg
+  # Turn TTY back on
+  stty echo 2>/dev/null
+  # Remove any escape or control characters
+  # Note: gnome-terminal tacked \e at end
+  bg=$(echo "$bg" | sed 's/[^a-zA-Z0-9/]//g')
+  [[ -z $bg ]] && return 1
+  # Convert to array
+  typeset -p bg
+  IFS='/' read -ra RGB_bg <<< "$bg"
+  typeset -p RGB_bg
+  xterm_osc_done=1
+  return 0
 }
 
 # From a comment left duthen in my StackOverflow answer cited above.
 osx_get_terminal_fg_bg() {
-    if [[ -n $COLORFGBG ]] ; then
-	method="COLORFGBG"
-	is_dark_colorfgbg
-    else
-	RGB_bg=($(osascript -e 'tell application "Terminal" to get the background color of the current settings of the selected tab of front window'))
-	# typeset -p RGB_bg
-	(($? != 0)) && return 1
-	TERMINAL_COLOR_MIDPOINT=117963
-	is_dark_rgb ${RGB_bg[@]}
-	method="OSX osascript"
-	success=1
-    fi
+  if [[ -n $COLORFGBG ]]; then
+    method="COLORFGBG"
+    is_dark_colorfgbg
+  else
+    RGB_bg=($(osascript -e 'tell application "Terminal" to get the background color of the current settings of the selected tab of front window'))
+    retsts=$?
+    # typeset -p RGB_bg
+    ((retsts != 0)) && return 1
+    is_dark_rgb ${RGB_fg[@]} ${RGB_bg[@]}
+    method="OSX osascript"
+    success=1
+  fi
 }
-
 
 typeset -i success=0
 typeset -i is_dark_bg=0
 typeset -i exitrc=0
+typeset -i xterm_osc_done=0
 
-get_default_bg
-
-if [[ ${BASH_VERSINFO[5]} == *"darwin"* ]] ; then
-    osx_get_terminal_fg_bg
-fi
-
-if (( !success )) && [[ -n $TERM ]] ; then
-    case $TERM in
-	xterm* | gnome | rxvt* )
-	    typeset -a RGB_fg RGB_bg
-	    if xterm_compatible_fg_bg ; then
-		is_dark_rgb ${RGB_bg[@]}
-		success=1
-	    fi
-	    ;;
-	* )
-	    ;;
-    esac
-fi
-
-if (( success )) ; then
-    if (( is_dark_bg == 1 )) ; then
-	echo "Dark background from ${method}"
+# Pre-analysis for non-COLORFGBG terminals
+if [ 3711 -lt "$VTE_VERSION" ] && [ -z "$COLORFGBG" ]; then
+  # Try Xterm Operating System Command (OSC) (Esc-])
+  if xterm_compatible_fg_bg; then
+    is_dark_rgb ${RGB_fg[@]} ${RGB_bg[@]}
+    if [[ $is_dark_bg == 1 ]]; then
+      # Even though, we're xterm, assist COLORFGBG
+      export COLORFGBG='0;15'
     else
-	echo "Light background from ${method}"
+      # Even though, we're xterm, assist COLORFGBG
+      export COLORFGBG='15;0'
     fi
-elif [[ -n $COLORFGBG ]] ; then
-    # Note that this can be wrong if
-    # COLORFGBG was set prior invoking a terminal
-    is_dark_colorfgbg
-    case $is_dark_bg in
-	0 )
-	    echo "Light background from COLORFGBG"
-	    ;;
-	1 )
-	    echo "Dark background from COLORFGBG"
-	    ;;
-	-1 | * )
-	    echo "Can't decide from COLORFGBG"
-	    exit_if_not_sourced 1
-	    ;;
-    esac
-else
-    echo "Can't decide"
+  else
+    echo "xterm/vte Esc-] OSC has empty string"
+    get_default_colorfgbg
+  fi
+  unset x fg bg avg_RGB_fg avg_RGB_bg
+fi
+
+if [[ ${BASH_VERSINFO[5]} == *"darwin"* ]]; then
+  osx_get_terminal_fg_bg
+fi
+
+if ((!success)) && [[ -n $TERM ]]; then
+  case $TERM in
+  xterm* | gnome | rxvt*)
+    typeset -a RGB_fg RGB_bg
+    if [[ $xterm_osc_done -eq 1 ]]; then
+      if xterm_compatible_fg_bg; then
+        is_dark_rgb ${RGB_fg[@]} ${RGB_bg[@]}
+      fi
+      success=1
+    fi
+    ;;
+  *) ;;
+
+  esac
+fi
+
+if ((success)); then
+  if ((is_dark_bg == 1)); then
+    echo "Dark background from ${method}"
+  else
+    echo "Light background from ${method}"
+  fi
+elif [[ -n $COLORFGBG ]]; then
+  # Note that this can be wrong if
+  # COLORFGBG was set prior invoking a terminal
+  is_dark_colorfgbg
+  case $is_dark_bg in
+  0)
+    echo "Light background from COLORFGBG"
+    ;;
+  1)
+    echo "Dark background from COLORFGBG"
+    ;;
+  -1 | *)
+    echo "Can't decide from COLORFGBG"
     exit_if_not_sourced 1
+    ;;
+  esac
+else
+  echo "Can't decide"
+  exit_if_not_sourced 1
 fi
 
 # If we were sourced, then set
 # some environment variables
-if is_sourced  ; then
-    if (( exitrc == 0 )) ; then
-	if (( is_dark_bg == 1 ))  ; then
-	    export DARK_BG=1  # deprecated
-	    export LC_DARK_BG=1
-	    [[ -z $COLORFGBG ]] && export COLORFGBG='0;15'
-	else
-	    export DARK_BG=0
-	    export LC_DARK_BG=0
-	    [[ -z $COLORFGBG ]] && export COLORFGBG='15;0'
-	fi
+if is_sourced; then
+  if ((exitrc == 0)); then
+    if ((is_dark_bg == 1)); then
+      export DARK_BG=1 # deprecated
+      export LC_DARK_BG=1
+      [[ -z $COLORFGBG ]] && export COLORFGBG='0;15'
+    else
+      export DARK_BG=0
+      export LC_DARK_BG=0
+      [[ -z $COLORFGBG ]] && export COLORFGBG='15;0'
     fi
+  fi
 else
-    exit 0
+  exit 0
 fi

--- a/term-background.bash
+++ b/term-background.bash
@@ -93,7 +93,7 @@ is_sourced() {
 exit_if_not_sourced() {
     exitrc=${1:-0}
     if ! is_sourced ; then
-	exit $exitrc
+	exit "$exitrc"
     fi
 }
 

--- a/term-background.bash
+++ b/term-background.bash
@@ -80,7 +80,7 @@ is_dark_colorfgbg() {
 }
 
 is_sourced() {
-    if [[ $0 == ${BASH_SOURCE[0]} ]] ; then
+    if [[ $0 == "${BASH_SOURCE[0]}" ]] ; then
 	return 1
     else
 	return 0

--- a/term-background.bash
+++ b/term-background.bash
@@ -104,7 +104,7 @@ exit_if_not_sourced() {
 #
 # User should set up RGB_fg and RGB_bg arrays
 xterm_compatible_fg_bg() {
-    typeset fg bg junk
+    typeset fg bg
     stty -echo 2>/dev/null
     # Issue command to get both foreground and
     # background color


### PR DESCRIPTION
I made a better background detector based on not only looking at the red element of the RGB, but the total sum of all 3-elements of an RGB, but only for the `xterm` portion.

Then (for `xterm`) I performed comparison between foreground RGB and background RGB to see who is "truly" the darker side.

Also, it has some more quirks to deal with `gnome-terminal` adding escape characters to the end of its ANSI OSC command response to the OSC foreground and OSC background commands.