### PR TITLE
Incorporate Rocky's request, and some forced integer operation, and `linux` TERM

### DIFF
--- a/term-background.bash
+++ b/term-background.bash
@@ -90,7 +90,7 @@ is_dark_colorfgbg() {
 }
 
 is_sourced() {
-  if [[ $0 == "${BASH_SOURCE[0]}" ]]; then
+  if [[ $0 == ${BASH_SOURCE[0]} ]]; then
     return 1
   else
     return 0
@@ -175,7 +175,8 @@ typeset -i exitrc=0
 typeset -i xterm_osc_done=0
 
 # Pre-analysis for non-COLORFGBG terminals
-if [ 3711 -lt "$VTE_VERSION" ] && [ -z "$COLORFGBG" ]; then
+let vte_version=$VTE_VERSION
+if [[ (( 3711 -lt vte_version )) && (( -z "$COLORFGBG" )) ]]; then
   # Try Xterm Operating System Command (OSC) (Esc-])
   if xterm_compatible_fg_bg; then
     is_dark_rgb ${RGB_fg[@]} ${RGB_bg[@]}
@@ -199,7 +200,7 @@ fi
 
 if ((!success)) && [[ -n $TERM ]]; then
   case $TERM in
-  xterm* | gnome | rxvt*)
+  xterm* | gnome | rxvt* | linux)
     typeset -a RGB_fg RGB_bg
     if [[ $xterm_osc_done -eq 1 ]]; then
       if xterm_compatible_fg_bg; then


### PR DESCRIPTION
- restore `is_sourced()` `BASH_SOURCE[0]` back to unquoted.
- Force it to integer mode for integer comparison because string comparison failed when leading zero appears during new pre-analysis for non-COLORFGBG/older VTE library.
- Added `linux` TERM to the same logic as `xterm*`, `gnome`, and `rxvt*` TERMs.